### PR TITLE
getlogin replacement via getpass

### DIFF
--- a/LUPY/commandlineArguments.py
+++ b/LUPY/commandlineArguments.py
@@ -11,7 +11,7 @@ and two functions for reading and writing data to the computerCodes member of a 
 """
 
 import argparse
-import os
+import getpass
 import socket
 
 import fudge
@@ -122,7 +122,7 @@ def commandLineArgumentsToDocumentation(codeName, commandLineArguments, document
     computerCode = computerCodeModule.ComputerCode(codeName, codeName, fudge.__version__)
     computerCode.executionArguments.body = ' '.join(commandLineArguments)
 
-    computerCode.note.body = f'Code {codeName} executed by {os.getlogin()} on platform {socket.gethostname()}.'
+    computerCode.note.body = f'Code {codeName} executed by {getpass.getuser()} on platform {socket.gethostname()}.'
 
     documentation.computerCodes.add(computerCode)
 


### PR DESCRIPTION
As mentioned in the Python documentation, [getpass.getuser](https://docs.python.org/3/library/getpass.html#getpass.getuser) should be preferred over [os.getlogin()](https://docs.python.org/3/library/os.html#os.getlogin).
This should fix the error raised in WSL2.