### PR TITLE
Some Python polishing for ElementTree, parenthesis and dummy

### DIFF
--- a/LUPY/ancestry.py
+++ b/LUPY/ancestry.py
@@ -40,7 +40,7 @@ import numpy
 import pathlib
 import inspect
 
-from xml.etree import cElementTree
+from xml.etree import ElementTree as ET
 
 from LUPY import xmlNode as xmlNodeMode        # Wrapper around the xml parser.
 from LUPY import checksums as checksumsModule
@@ -651,7 +651,7 @@ class AncestryIO_base(Ancestry):
 
         if not isinstance(string, str): raise TypeError('Invalid string.')
 
-        node = cElementTree.fromstring(string)
+        node = ET.fromstring(string)
         node = xmlNodeMode.XML_node(node, xmlNodeMode.XML_node.etree)
 
         instance = cls.parseNodeUsingClass(node, [], {}, **kwargs)
@@ -675,7 +675,7 @@ class AncestryIO_base(Ancestry):
             fileName = str(fileName)
         if not isinstance(fileName, str): raise TypeError('Invalid file name.')
 
-        node = cElementTree.parse(fileName).getroot()
+        node = ET.parse(fileName).getroot()
         node = xmlNodeMode.XML_node(node, xmlNodeMode.XML_node.etree)
 
         if node.tag != cls.moniker:

--- a/PoPs/Test/Misc/c.py
+++ b/PoPs/Test/Misc/c.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # <<END-copyright>>
 
-from xml.etree import cElementTree
+from xml.etree import ElementTree as ET
 
 from PoPs import database as databaseModule
 from PoPs import alias as aliasModule
@@ -16,7 +16,7 @@ from PoPs.chemicalElements import chemicalElement as chemicalElementModule
 
 pops = databaseModule.Database( 'LLNL', '0.0.1' )
 
-element = cElementTree.parse( 'pops.xml' )
+element = ET.parse( 'pops.xml' )
 element = element.getroot( )
 
 def aliases( element ) :

--- a/PoPs/Test/Misc/c.py
+++ b/PoPs/Test/Misc/c.py
@@ -33,12 +33,12 @@ def gaugeBosons( element ) :
 def baryons( element ) :
 
     for child in element :
-        pops.add baryonModule.Particle.parseNodeUsingClass(child , [], [ ))
+        pops.add(baryonModule.Particle.parseNodeUsingClass(child , [], [] ))
  
 def chemicalElements( element ) :
 
     for child in element :
-        pops.add chemicalElementModule.Suite.parseNodeUsingClass(child, [], []))
+        pops.add(chemicalElementModule.Suite.parseNodeUsingClass(child, [], []))
  
 for child in element :
     if( child.tag == 'aliases' ) :

--- a/PoPs/Test/Misc/za.py
+++ b/PoPs/Test/Misc/za.py
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # <<END-copyright>>
 
-from xml.etree import cElementTree
-
 from PoPs import database as databaseModule
 
 from PoPs import misc as miscModule

--- a/PoPs/bin/Q.py
+++ b/PoPs/bin/Q.py
@@ -49,7 +49,7 @@ def compoundZandA(pops, particleList):
 
     for particleId in particleIds:
         particle = pops[particleId]
-        Zp, Ap, dummy, dummy = chemicalElementsMiscModule.ZAInfo(particle)
+        Zp, Ap, _, _ = chemicalElementsMiscModule.ZAInfo(particle)
         Z += Zp
         A += Ap
 

--- a/PoPs/bin/checkPoPs.py
+++ b/PoPs/bin/checkPoPs.py
@@ -39,7 +39,7 @@ def printMissing(message, missing):
     if len(missing) > 0:
         idFormat = '%%-%ds' % max([len(pid) for pid in missing])
         diff = sorted([[pid.lower(), pid] for pid in missing])
-        pids = [idFormat % pid for dummy, pid in diff]
+        pids = [idFormat % pid for _, pid in diff]
         for index in range(0, len(pids), args.missingPerLine):
             print('    %s' % ' '.join(pids[index:index+args.missingPerLine]))
 

--- a/PoPs/bin/diffPoPs.py
+++ b/PoPs/bin/diffPoPs.py
@@ -56,7 +56,7 @@ def missingIds(pops, args, set1, set2, first):
     if len(diffList) > 0:
         idFormat = '%%-%ds' % max([len(pid) for pid in diffList])
         diff = sorted([[pid.lower(), pid] for pid in diffList])
-        pids = [idFormat % pid for dummy, pid in diff]
+        pids = [idFormat % pid for _, pid in diff]
         for index in range(0, len(pids), args.missingPerLine):
             print('    %s' % ' '.join(pids[index:index+args.missingPerLine]))
 
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     missingIds(pops2, args, set2, set1, False)
 
     intersection = sorted([[pid.lower(), pid] for pid in set1.intersection(set2)])
-    intersection = list(pid for dummy, pid in intersection)
+    intersection = list(pid for _, pid in intersection)
     if args.mass:
         print('Mass difference (%s):' % massUnit)
         header = '    %-12s %-20s %-20s  %-10s %-10s' % ('id', 'mass-1', 'mass-2', 'diff', 'rel-diff')

--- a/PoPs/database.py
+++ b/PoPs/database.py
@@ -385,7 +385,7 @@ class Database(ancestryModule.AncestryIO):
         except:
             pass
 
-        dummy, symbol, A, level, dummy, dummy, dummy = chemicalElementsMiscModule.chemicalElementALevelIDsAndAnti(pid)
+        _, symbol, A, level, _, _, _ = chemicalElementsMiscModule.chemicalElementALevelIDsAndAnti(pid)
         if symbol is None:
             return None
         try:

--- a/bin/HDFtoXML.py
+++ b/bin/HDFtoXML.py
@@ -13,7 +13,7 @@ Translate GNDS/HDF5 to GNDS/XML
 import sys
 import os
 
-from xml.etree import cElementTree as etree
+from xml.etree import ElementTree as ET
 import numpy
 import h5py
 
@@ -33,11 +33,11 @@ def addNode( parent, node ):
     name = attrs.pop( "_xmltag" )
 
     try:
-        xmlnode = etree.Element( name )
+        xmlnode = ET.Element( name )
         for key,val in attrs.items():
             if key.startswith("_xml"): continue
             xmlnode.set( str(key), str(val) )
-        if isinstance( parent, etree.ElementTree ): parent._setroot( xmlnode )
+        if isinstance( parent, ET.ElementTree ): parent._setroot( xmlnode )
         else: parent.append( xmlnode )
         newParent = xmlnode
 
@@ -71,7 +71,7 @@ if __name__ == '__main__':
     h5file = sys.argv[1]
     h5 = h5py.File( h5file, "r" )
 
-    xdoc = etree.ElementTree()
+    xdoc = ET.ElementTree()
 
     root = list(h5.values())[0]
     addNode( xdoc, root )

--- a/bin/XMLtoHDF.py
+++ b/bin/XMLtoHDF.py
@@ -16,7 +16,7 @@ import argparse
 import numpy
 from collections import Counter
 
-from xml.etree import cElementTree
+from xml.etree import ElementTree as ET
 import h5py
 
 parser = argparse.ArgumentParser()
@@ -121,7 +121,7 @@ def addDocumentation( parent, node, index, suffix=None ):
 if __name__ == '__main__':
     args = parser.parse_args()
 
-    xdoc = cElementTree.parse( args.xml )
+    xdoc = ET.parse( args.xml )
 
     if args.output is not None:
         h5file = args.output
@@ -140,4 +140,3 @@ if __name__ == '__main__':
 
     root = xdoc.getroot()
     addNode( h5, root, index=0 )
-

--- a/bin/checkExternalFiles.py
+++ b/bin/checkExternalFiles.py
@@ -87,7 +87,7 @@ def checkProtare(path):
         for externalFile in protare.externalFiles:
             realpath = externalFile.realpath()
             if pathlib.Path(realpath).exists():
-                name, dummy = GNDS_fileModule.type(realpath)
+                name, _ = GNDS_fileModule.type(realpath)
                 if name == GNDS_fileModule.HDF5_values:
                     pass
                 elif name == covarianceSuiteModule.CovarianceSuite.moniker:

--- a/bin/checkMap.py
+++ b/bin/checkMap.py
@@ -128,7 +128,7 @@ def checkProtare( protareFileName, map, entry ) :
         for externalFile in protare.externalFiles:
             realpath = externalFile.realpath()
             if os.path.exists(realpath):
-                name, dummy = GNDS_fileModule.type(realpath)
+                name, _ = GNDS_fileModule.type(realpath)
                 if name == GNDS_fileModule.HDF5_values:
                     hdf5ExternalFiles.add(realpath)
                     hdf5Directories.add(os.path.dirname(realpath))
@@ -209,7 +209,7 @@ for protareDirectory in protareDirectories :
             dirsInDirectories.add( file )
         else :
             try:
-                name, dummy = GNDS_fileModule.type(file)
+                name, _ = GNDS_fileModule.type(file)
                 if( name == mapModule.Map.moniker ) :
                     mapsInDirectories.add( file )
                 elif( name == reactionSuiteModule.ReactionSuite.moniker ) :
@@ -234,7 +234,7 @@ for hdf5Directory in hdf5Directories :
                 if( os.path.isdir( file ) ) :
                     mapsInDirectories.add( file )
                 else :
-                    name, dummy = GNDS_fileModule.type(file)
+                    name, _ = GNDS_fileModule.type(file)
                     if( name != GNDS_fileModule.HDF5_values) : unknownsInHDF5_directories.add(file)
             except :
                 unknownsInHDF5_directories.add( file )

--- a/bin/cullStyles.py
+++ b/bin/cullStyles.py
@@ -33,7 +33,7 @@ if __name__ == '__main__' :
 
     args = parser.parse_args( )
 
-    name, dummy = GNDS_fileModule.type(args.gnds)
+    name, _ = GNDS_fileModule.type(args.gnds)
 
     if( name == reactionSuiteModule.ReactionSuite.moniker ) :
             gnds = GNDS_fileModule.read(args.gnds)

--- a/bin/energySpectrum.py
+++ b/bin/energySpectrum.py
@@ -352,7 +352,7 @@ if outputDir is not None:
 
 totalSpectraTime = timesModule.Times( )
 reactionSpectrumNonDiscrete, discreteGammaData, totalCrossSection = getSpectrum(protare.reactions, '')
-orphanSpectrum, dummy, dummy = getSpectrum(protare.orphanProducts, ' (orphan product)')
+orphanSpectrum, _, _ = getSpectrum(protare.orphanProducts, ' (orphan product)')
 totalSpectraTime = totalSpectraTime.toString( current = False )
 
 discreteGammaSpectrum = discreteGammaSpectrumToPDF( discreteGammaData )

--- a/bin/gnds2gnds.py
+++ b/bin/gnds2gnds.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
     fileName = args.input
 
     covariances = []
-    name, dummy = GNDS_fileModule.type(fileName)
+    name, _ = GNDS_fileModule.type(fileName)
     if name == databaseModule.Database.moniker:
         gnds = GNDS_fileModule.read(fileName, lazyParsing=False)
     else:

--- a/bin/listBreakupReactions.py
+++ b/bin/listBreakupReactions.py
@@ -26,7 +26,7 @@ for file in args.paths :
         MTData = MTDatas[MT]
         if( 3 in MTData ) :
             MF3 = MTData[3]
-            dummy, dummy, dummy, LR, dummy, dummy = endfFileToGNDSMisc.sixFunkyFloatStringsToFloats(MF3[1])
+            _, _, _, LR, _, _ = endfFileToGNDSMisc.sixFunkyFloatStringsToFloats(MF3[1])
             if( LR != 0 ) :
                 counter += 1
                 if( args.verbose ) : 

--- a/bin/processProtare.py
+++ b/bin/processProtare.py
@@ -83,7 +83,7 @@ an example of a valid input file:
 
 parserPreview = argparse.ArgumentParser(fromfile_prefix_chars='@', add_help=False)
 parserPreview.add_argument('-mg', '--MultiGroup', action='store_true')
-argsPreview, dummy = parserPreview.parse_known_args()
+argsPreview, _ = parserPreview.parse_known_args()
 multigroupPresent = argsPreview.MultiGroup
 
 class ProcessProtareArgumentParser(argparse.ArgumentParser):

--- a/brownies/LANL/toACE/gndsToACE.py
+++ b/brownies/LANL/toACE/gndsToACE.py
@@ -474,7 +474,7 @@ def processEnergyData( massUnit, neutronMass, energyDatas, JXS, XSS, nonFissionE
     for MT, EMin, EMax, energyData in energyDatas :
         n_multiplicity = []
         if MT in nonFissionEnergyDependentNeutronMultiplicities:        # Fixup the TYR data whose abs( value ) is greater than 100.
-            TYR_index, index, multiplicity, dummy = nonFissionEnergyDependentNeutronMultiplicities[MT]
+            TYR_index, index, multiplicity, _ = nonFissionEnergyDependentNeutronMultiplicities[MT]
             JXS5 = JXS[5-1]
             if abs( XSS[JXS5+TYR_index-1] ) != index: raise Exception( 'Neutron multiplicity for index %s not found in TYR table' % index )
             n_multiplicity = multiplicity.toACE( )

--- a/brownies/LLNL/bin/bdflsToFluxes.py
+++ b/brownies/LLNL/bin/bdflsToFluxes.py
@@ -49,7 +49,7 @@ if( __name__ == '__main__' ) :
                 orders.append( flux )
                 grid += flux
             flux = [ ]
-            for energy, dummy in grid :
+            for energy, _ in grid :
                 energyLegendreCoefficients = '%s' % energy
                 for order in orders : energyLegendreCoefficients += ' %s' % order.evaluate( energy )
                 flux.append( energyLegendreCoefficients )

--- a/brownies/bin/ENDF_dump.py
+++ b/brownies/bin/ENDF_dump.py
@@ -39,7 +39,7 @@ def LIST(fOut, label, lineIndex, MFData):
     '''Writes to *fOut* an ENDF-6 list record that starts a line *lineIndex* of *MFData*.'''
 
     priorIndex = lineIndex
-    dummy, dummy, dummy, dummy, NLP, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+    _, _, _, _, NLP, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
     NLP = int(NLP)
     lineIndex += 1 + (NLP + 5) // 6
     printlines(fOut, label, priorIndex, lineIndex, MFData)
@@ -50,7 +50,7 @@ def TAB1(fOut, label, lineIndex, MFData):
     '''Writes to *fOut* an ENDF-6 tab1 record that starts a line *lineIndex* of *MFData*.'''
 
     priorIndex = lineIndex
-    dummy, dummy, dummy, dummy, NR, NP = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+    _, _, _, _, NR, NP = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
     NR, NP = int(NR), int(NP)
     lineIndex += 1 + (NR + 2) // 3
     lineIndex += (NP + 2) // 3
@@ -67,7 +67,7 @@ def TAB2header(fOut, label, lineIndex, MFData):
     '''Writes the header information for an ENDF-6 tab2 record.'''
 
     priorIndex = lineIndex
-    dummy, dummy, dummy, dummy, NR, NZ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+    _, _, _, _, NR, NZ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
     NR, NZ = int(NR), int(NZ)
     lineIndex += 1 + (NR + 2) // 3
 
@@ -126,7 +126,7 @@ def LAW5(fOut, lineIndex, MFData):
 def LAW6(fOut, lineIndex, MFData):
     '''Writes to *fOut* MF 6, law 6 data.'''
 
-    APSX, dummy, dummy, dummy, dummy, NPSX = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+    APSX, _, _, _, _, NPSX = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
     printlines(fOut, '', lineIndex, lineIndex+1, MFData)
     return lineIndex + 1
 
@@ -134,7 +134,7 @@ def LAW7(fOut, lineIndex, MFData):
     '''Writes to *fOut* MF 6, law 7 data.'''
 
     priorIndex = lineIndex
-    dummy, dummy, dummy, dummy, NR, NE = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+    _, _, _, _, NR, NE = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
     NR, NE = int(NR), int(NE)
     lineIndex += 1 + (NR + 2) // 3
     printlines(fOut, '', priorIndex, lineIndex, MFData)
@@ -169,8 +169,8 @@ def process(inputFile, outputDir):
                         TAB1(fOut, '', 1, MFData)
                 elif MF == 4:
                     priorIndex = lineIndex
-                    ZA,    AWR, dummy, LTT,   dummy, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
-                    dummy, AWR, LI,    dummy, dummy, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex+1])
+                    ZA,    AWR, _, LTT,   _, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+                    _, AWR, LI,    _, _, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex+1])
                     lineIndex += 2
 
                     LTT = int(LTT)
@@ -188,7 +188,7 @@ def process(inputFile, outputDir):
                             lineIndex = TAB2withLIST(fOut, ' Energy', lineIndex, MFData)
                             lineIndex = TAB2withTAB1(fOut, '', ' Energy', lineIndex, MFData)
                 elif MF in [6, 26]:
-                    ZA, AWR, JP, LCT, NK, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+                    ZA, AWR, JP, LCT, NK, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
                     NK = int(NK)
                     lineIndex += 1
                     for productIndex in range(NK):
@@ -223,7 +223,7 @@ def process(inputFile, outputDir):
                             break
                 elif MF in [12, 13]:
                     fileName = filePrefix
-                    ZA, AWR, LO, LG, NK, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
+                    ZA, AWR, LO, LG, NK, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(MFData[lineIndex])
                     LO = int(LO)
                     LG = int(LG)
                     NK = int(NK)

--- a/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_0_Misc.py
+++ b/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_0_Misc.py
@@ -265,7 +265,7 @@ def getMultiplicityPointwiseOrPieceWise(info, data, warningList):
 def getTotalOrPromptFission(info, MT, MTDatas, totalOrPrompt, warningList):
 
     MT456Data = MTDatas[MT][1]
-    ZA, AWR, dummy, LNU, dummy, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(
+    ZA, AWR, _, LNU, _, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(
         MT456Data[0], logFile=info.logs)
     ZA = int(ZA)
     info.ZA_massLineInfo.add(ZA, AWR, MT, 1, 0)
@@ -290,7 +290,7 @@ def getDelayedFission(info, MT, MTDatas, warningList):
     info.logs.write('     Delayed fission neutron data (MT=455)')
     MT455Data = MTDatas[MT]
     MT455DataMF1 = MT455Data[1]
-    ZA, AWR, LDG, LNU, dummy, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(
+    ZA, AWR, LDG, LNU, _, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(
         MT455DataMF1[0], logFile=info.logs)
     ZA = int(ZA)
     info.addMassAWR(ZA, AWR)
@@ -405,14 +405,14 @@ def getFissionEnergies(info, domainMin, domainMax, warningList):
 
     MF1Data = info.fissionEnergyReleaseData[1]
     dataLine = 0
-    ZA, AWR, dummy, LFC, dummy, NFC = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
+    ZA, AWR, _, LFC, _, NFC = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
         MF1Data[dataLine], intIndices=[0, 5], logFile=info.logs)
     info.ZA_massLineInfo.add(ZA, AWR, 458, 1, 0)
     ZA = int(ZA)
     info.addMassAWR(ZA, AWR)
 
     dataLine += 1
-    dummy, dummy, dummy, NPLY, N1, N2 = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(
+    _, _, _, NPLY, N1, N2 = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats(
         MF1Data[dataLine], logFile=info.logs)
     if (N2 != (NPLY+1) * 9) or (N1 != N2 * 2): warningList.append("Inconsistent N1/N2/NPLY in section MF=1 MT=458!")
     nCoeffs = int(N2)  # total number of coefficients for all energy release components (each also has an uncertainty)
@@ -1540,14 +1540,14 @@ def readMF3( info, MT, MF3Data, warningList ) :
 def readMF4(info, product, MT, MF4Data, formClass, warningList):
 
     if MT not in MTWithOnlyNeutronProducts: info.MF4ForNonNeutrons.append(MT)
-    ZA, AWR, LVT, LTT, dummy, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF4Data[0], logFile = info.logs )
+    ZA, AWR, LVT, LTT, _, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF4Data[0], logFile = info.logs )
     ZA = int( ZA )
     printAWR_mode(info, MT, 4, 0, ZA, AWR)
     info.addMassAWR( ZA, AWR )
     LVT = int( LVT )                # 1: transformation matrix given. Must be 0 for endf/b6 format but not older formats.
     LTT = int( LTT )                # 0: isotropic, 1: Legendre, 2: table, 3: Legendre for low E and table for high E.
 
-    dummy, AWR_, LI, LCT, NK, NM = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF4Data[1], logFile = info.logs )
+    _, AWR_, LI, LCT, NK, NM = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF4Data[1], logFile = info.logs )
     if AWR != AWR_:
         printAWR_mode(info, MT, 4, 1, ZA, AWR)
     else:
@@ -1589,7 +1589,7 @@ def readMF4(info, product, MT, MF4Data, formClass, warningList):
 
 def readMF5(info, MT, MF5Data, warningList, delayNeutrons=False, product=None):
 
-    ZA, AWR, dummy, dummy, NK, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF5Data[0], logFile = info.logs )
+    ZA, AWR, _, _, NK, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF5Data[0], logFile = info.logs )
     ZA = int( ZA )
     printAWR_mode( info, MT, 5, 0, ZA, AWR )
     info.addMassAWR( ZA, AWR )
@@ -1688,7 +1688,7 @@ def readMF5(info, MT, MF5Data, warningList, delayNeutrons=False, product=None):
 def readMF6(MT, info, MF6Data, productList, warningList, undefinedLevelInfo, isTwoBody, crossSection, LR, compoundZA=None):
 
     twoBodyIndex = 0
-    ZA, AWR, JP, LCT, NK, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[0], logFile = info.logs )
+    ZA, AWR, JP, LCT, NK, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[0], logFile = info.logs )
     ZA = int( ZA )
     doInfo = not (ZA == 0 and AWR != 0)
     printAWR_mode(info, MT, 6, 0, ZA, AWR, doInfo)
@@ -1746,7 +1746,7 @@ def readMF6(MT, info, MF6Data, productList, warningList, undefinedLevelInfo, isT
         if( LAW == 0 ) :
             form = unspecifiedModule.Form( info.style, frame )
         elif( LAW == 1 ) :              # Continuum Energy-Angle distributions
-            dummy, dummy, LANG, LEP, NR, NE = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[ dataLine ], logFile = info.logs )
+            _, _, LANG, LEP, NR, NE = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[ dataLine ], logFile = info.logs )
             LANG = int( LANG )          # identifies the type of data
             info.logs.write( ', LANG=%s' % LANG )
             LEP = int( LEP )            # interpolation type for outgoing energy
@@ -1765,7 +1765,7 @@ def readMF6(MT, info, MF6Data, productList, warningList, undefinedLevelInfo, isT
                 maxLegendre = 0
                 EEpClsData = []
                 for EinCount in range( NE ) :
-                    dummy, Ein, ND, NA, NW, NEP = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[dataLine], logFile = info.logs )
+                    _, Ein, ND, NA, NW, NEP = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[dataLine], logFile = info.logs )
                     ND = int( ND )          # number of discrete gammas (nonzero only for gammas)
                     NA = int( NA )          # number of angular parameters (i.e., lMax).
                     NW = int( NW )          # number of data values for this incident energy
@@ -2040,7 +2040,7 @@ def readMF6(MT, info, MF6Data, productList, warningList, undefinedLevelInfo, isT
 
                 muInterpolationQualifier, muInterpolation = endfFileToGNDSMiscModule.ENDFInterpolationToGNDS2plusd( LANG - 10 )
                 for EinCount in range( NE ) :
-                    dummy, Ein, ND, NA, NW, NEP = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[dataLine], logFile = info.logs )
+                    _, Ein, ND, NA, NW, NEP = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[dataLine], logFile = info.logs )
                     ND = int( ND )          # number of discrete gammas (nonzero only for gammas)
                     NA = int( NA )          # number of angular parameters (i.e., the number of mu values).
                     NW = int( NW )          # number of data values for this incident energy
@@ -2139,7 +2139,7 @@ def readMF6(MT, info, MF6Data, productList, warningList, undefinedLevelInfo, isT
             # also make a link from 'normal' distribution to differential part:
             form = referenceModule.CoulombPlusNuclearElastic( link=dSigma_form, label=info.style, relative=True )
         elif( LAW == 6 ) :
-            APSX, dummy, dummy, dummy, dummy, NPSX = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[ dataLine ], logFile = info.logs )
+            APSX, _, _, _, _, NPSX = endfFileToGNDSMiscModule.sixFunkyFloatStringsToFloats( MF6Data[ dataLine ], logFile = info.logs )
             dataLine += 1
             APSX *= info.massTracker.neutronMass
             angularSubform = angularModule.Isotropic2d( )
@@ -2426,7 +2426,7 @@ def readMF8(info, MT, MTData, warningList):
         MF10Data = readMF9or10( info, MT, MTData, 10, LIS, warningList )
         metastables = {}
         for idx in range( NS ) :
-            ZAP, ELFS, LMF, LFS, ND6, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
+            ZAP, ELFS, LMF, LFS, ND6, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
                 MF8Data[dataLine], intIndices = [ 0, 2, 3, 4 ], logFile = info.logs )
 
             if LMF in (9, 10):
@@ -2532,7 +2532,7 @@ def readMF9or10(info, MT, MTData, MF, targetLIS, warningList):
 
     if MF not in MTData.keys(): return None
     dataLine, MFData, MF9or10 = 1, MTData[MF], []
-    ZA, AWR, LIS, dummy, NS, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
+    ZA, AWR, LIS, _, NS, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
         MFData[0], intIndices=[0, 2, 4], logFile=info.logs)
     ZA = int(ZA)
     printAWR_mode(info, MT, MF, 0, ZA, AWR, LIS=LIS)
@@ -2611,7 +2611,7 @@ def readMF12_13(info, MT, MTData, productList, warningList, crossSection, _dummy
     if MF6gammas:
         warningList.append(f'MT{MT} photons are likely double-counted, in MF6 and MF{MF}')
         info.doRaise.append(warningList[-1])
-    ZA, AWR, LO, LG, NK, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
+    ZA, AWR, LO, LG, NK, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
         MF12_13Data[0], intIndices=[0, 2, 3, 4], logFile=info.logs)
     printAWR_mode(info, MT, MF, 0, ZA, AWR)
     info.addMassAWR(ZA, AWR)
@@ -2749,7 +2749,7 @@ def readMF15(info, MT, MTData, continuousGamma, warningList):
         warningList.append('MF=15 data and no continous gamma MF=12,13 data: MT=%s' % MT)
         info.doRaise.append(warningList[-1])
     MF15Data = MTData[15]
-    ZA, AWR, dummy, dummy, NC, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
+    ZA, AWR, _, _, NC, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
         MF15Data[0], intIndices=[0, 4], logFile=info.logs)
     printAWR_mode(info, MT, 15, 0, ZA, AWR)
     info.addMassAWR(ZA, AWR)
@@ -3953,7 +3953,7 @@ def parseMF6FissionData(info, MT, MF6Data, fissionNeutronsAndGammasDataFromMF6, 
 
     print("    WARNING: parseMF6FissionData function not complete.")
     dataLine = 0
-    ZA, AWR, JP, LCT, NK, dummy = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
+    ZA, AWR, JP, LCT, NK, _ = endfFileToGNDSMiscModule.sixFunkyFloatStringsToIntsAndFloats(
         MF6Data[dataLine], intIndices=[0, 2, 3, 4], logFile=info.logs)
     info.ZA_massLineInfo.add(ZA, AWR, MT, 6, 0)
     dataLine += 1

--- a/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_2.py
+++ b/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_2.py
@@ -310,7 +310,7 @@ def readMF7(info, MT, MF7):
     forms = []
     if LTHR in (1, 3):  # coherent elastic scattering
 
-        line, temps, energies, dummy, data, e_interp, t_interp = readSTable(line, MF7)
+        line, temps, energies, _, data, e_interp, t_interp = readSTable(line, MF7)
         temps, energies = map(valuesModule.Values, (temps, energies))
 
         if e_interp != xDataEnumsModule.Interpolation.flat:

--- a/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_4.py
+++ b/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_4.py
@@ -288,7 +288,7 @@ def ITYPE_4(MTDatas, info, verbose=0):
             aliasID = "%s_m%s" % (parentAtom.isotope.symbol, LISO)
             info.PoPs.add(PoPsAliasModule.MetaStable(aliasID, parentAtom.id, LISO))
 
-        HL, dHL, dummy, dummy, NC2, dummy = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
+        HL, dHL, _, _, NC2, _ = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
             MT457MF8Data[dataIndex], intIndices=[4])
         dataIndex += printInfo(verbose, dataIndex, MT457MF8Data)
 

--- a/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_6.py
+++ b/brownies/legacy/converting/ENDFToGNDS/ENDF_ITYPE_6.py
@@ -57,15 +57,15 @@ def ITYPE_6(Z, MTDatas, info, verbose=0):
     chemicalElement.atomicData = atomicData
 
     offset = 0
-    ZA, AWP, dummy, dummy, NSS, dummy = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
+    ZA, AWP, _, _, NSS, _ = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
         MF28[offset], intIndices=[4], logFile=info.logs)
     info.ZA_massLineInfo.add(ZA, AWP, MT, 28, offset)
     offset += 1
     for subshell in range(NSS):
-        SUBI, dummy, dummy, dummy, dummy, NTR = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
+        SUBI, _, _, _, _, NTR = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
             MF28[offset], intIndices=[0, 5], logFile=info.logs)
         offset += 1
-        EBI, ELN, dummy, dummy, dummy, dummy = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
+        EBI, ELN, _, _, _, _ = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
             MF28[offset], intIndices=[], logFile=info.logs)
         offset += 1
 
@@ -78,7 +78,7 @@ def ITYPE_6(Z, MTDatas, info, verbose=0):
         probabilitySum = 0.
         info.logs.write(' : %s' % MT_AtomicConfigurations[534 + SUBI - 1])
         for i1 in range(NTR):
-            SUBJ, SUBK, ETR, FTF, dummy, dummy = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
+            SUBJ, SUBK, ETR, FTF, _, _ = endfFileToGNDSMisc.sixFunkyFloatStringsToIntsAndFloats(
                 MF28[offset], intIndices=[0, 1], logFile=info.logs)
             offset += 1
 

--- a/brownies/legacy/converting/endfFileToGNDS.py
+++ b/brownies/legacy/converting/endfFileToGNDS.py
@@ -92,7 +92,7 @@ def readMF1MT451(_MAT, _MTDatas, formatVersion, specialNuclearParticleID, styleN
     isNaturalTarget = (targetZA % 1000) == 0
 
     # Line #2
-    targetExcitationEnergy, STA, LIS, LISO, dummy, NFOR = \
+    targetExcitationEnergy, STA, LIS, LISO, _, NFOR = \
         endfFileToGNDSMisc.sixFunkyFloatStringsToFloats(_MTDatas[451][1][1], logFile=logFile)
     STA = int(STA)  # Is nucleus unstable
     LIS = int(LIS)  # Excitation number
@@ -109,7 +109,7 @@ def readMF1MT451(_MAT, _MTDatas, formatVersion, specialNuclearParticleID, styleN
     info.ZA_massLineInfo.targetLIS = LIS
     info.ZA_massLineInfo.add(targetZA, targetMass, 451, 1, 0)
     # Line #3
-    projectileMass, EMAX, LREL, dummy, NSUB, NVER = \
+    projectileMass, EMAX, LREL, _, NSUB, NVER = \
         endfFileToGNDSMisc.sixFunkyFloatStringsToFloats(_MTDatas[451][1][2], logFile=logFile)
     NSUB = int(NSUB)  # 10 * ZA + iType for projectile
     NVER = int(NVER)  # Evaluation version number
@@ -120,7 +120,7 @@ def readMF1MT451(_MAT, _MTDatas, formatVersion, specialNuclearParticleID, styleN
     info.ZA_massLineInfo.add(projectileZA, projectileMass, 451, 1, 2)
 
     # Line #4
-    targetTemperature, dummy, LDRZ, dummy, NWD, NXC = \
+    targetTemperature, _, LDRZ, _, NWD, NXC = \
         endfFileToGNDSMisc.sixFunkyFloatStringsToFloats(_MTDatas[451][1][3], logFile=logFile)
     LDRZ = int(LDRZ)  # Primary or special evaluation of this material
     NWD = int(NWD)  #

--- a/brownies/legacy/converting/endlToGNDS.py
+++ b/brownies/legacy/converting/endlToGNDS.py
@@ -20,7 +20,7 @@ gamma: name is simply given as 'photon'.
 
 import os
 import numpy
-from xml.etree import cElementTree
+from xml.etree import ElementTree as ET
 
 from pqu import PQU as PQUModule
 
@@ -140,7 +140,7 @@ def parse_endl_covariance(covFile):
     Returns a list of (energy bins,  covariance matrix, covariance_type, [enminmax]) tuples.
     The list may be empty (some ENDL cov.xml files are empty).
     """
-    xdoc = cElementTree.parse(covFile)
+    xdoc = ET.parse(covFile)
     root = xdoc.getroot()
     ebins, covariances, covariance_types, enminmax = [],[],[],[]
     # should I just set the I# here and return it?

--- a/brownies/legacy/converting/parse_endl_covariances.py
+++ b/brownies/legacy/converting/parse_endl_covariances.py
@@ -13,7 +13,7 @@ python parse_endl_covariances.py /usr/gapps/data/nuclear/endl_official/endl2009.
 import sys
 import os
 import numpy
-from xml.etree import cElementTree
+from xml.etree import ElementTree as ET
 
 def covarianceDict(rootdir):  #  ACD ADDED THIS CHUNK
     """
@@ -37,7 +37,7 @@ def parse_endl_covariance(covFile):
     Returns a list of (energy bins,  covariance matrix, covariance_type) tuples.
     The list may be empty (some ENDL cov.xml files are empty).
     """
-    xdoc = cElementTree.parse(covFile)
+    xdoc = ET.parse(covFile)
     root = xdoc.getroot()
     if root.tag not in ('cross_section_covariance'):
         # to-be-done: support energy distribution covariances like za094239/yo01c15i005s000_cov.xml
@@ -61,4 +61,3 @@ def parse_endl_covariance(covFile):
 if __name__ == '__main__':
     results = parse_endl_covariance(sys.argv[1])
     print("Read %d covariances from file %s" % (len(results), sys.argv[1]))
-

--- a/brownies/legacy/endl/endlIClasses.py
+++ b/brownies/legacy/endl/endlIClasses.py
@@ -65,7 +65,7 @@ class endlI0(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -150,7 +150,7 @@ class endlI7(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -195,7 +195,7 @@ class endlI9(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -246,7 +246,7 @@ class endlI10(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -291,7 +291,7 @@ class endlI11(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = True, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -336,7 +336,7 @@ class endlI12(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -381,7 +381,7 @@ class endlI13(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -425,7 +425,7 @@ class endlI80(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -449,7 +449,7 @@ class endlI89(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -473,7 +473,7 @@ class endlI90(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -497,7 +497,7 @@ class endlI91(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -521,7 +521,7 @@ class endlI92(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -546,7 +546,7 @@ class endlI941(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -583,7 +583,7 @@ class endlI942(endlNd.endlNd, endl2dmathClasses.endl2dmath) :
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )
@@ -619,7 +619,7 @@ class endlI951(endlNd.endlNd, endl2dmathClasses.endl2dmath) : # Special I = 951 
         See endl2dmathmisc.check2dData for meaning of printWarning and printErrors."""
 
         ErrMsgs = []
-        n, dummy, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
+        n, _, messages2d = endl2dmathmisc.check2dData(self.data, allowZeroX = allowZeroE, positiveY = False, printWarning = printWarning, \
                                                           printErrors = printErrors, xCloseEps = xCloseEps, maxAbsFloatValue = maxAbsFloatValue)
         if( len( messages2d ) > 0 ) : ErrMsgs.append(endlmisc.endlCheckerObject(data = self, message = messages2d))
         return( ErrMsgs )

--- a/brownies/legacy/endl/structure/xml2py.py
+++ b/brownies/legacy/endl/structure/xml2py.py
@@ -5,11 +5,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # <<END-copyright>>
 
-from xml.etree.ElementTree import ElementTree, tostring, Element
+from xml.etree import ElementTree as ET
 
 class XML2PY( object ) :
     def __init__( self ) :
-        self.etree = ElementTree( )
+        self.etree = ET.ElementTree( )
     def __repr__( self ): return repr( self.__dict__ )
     def __setattr__( self, attr, val ) :
         if attr not in ['xml', 'etree'] :
@@ -17,7 +17,7 @@ class XML2PY( object ) :
                 self.xml.set( attr, str( val ) )
         return object.__setattr__( self, attr, val )
     def newXMLElement( self, attr, val={}, index=0 ) :
-        element = Element( attr.capitalize( ), val )
+        element = ET.Element( attr.capitalize( ), val )
         element.text = None
         element.tail = '\n    '
         self.xml.insert( index, element )
@@ -35,7 +35,7 @@ class XML2PY( object ) :
             x.append( XML2PY._get_py( element ) )
         return x
     def toxml( self ) :
-        return tostring( self.xml )
+        return ET.tostring( self.xml )
     def write( self, xmlfile ) :
         self.etree.write( xmlfile )
     def fixIndentation( self ) :
@@ -98,4 +98,3 @@ if __name__=='__main__':
     print( x.toxml() )
     x.fixIndentation()
     print( x.toxml() )
-

--- a/brownies/legacy/toENDF6/gndsToENDF6.py
+++ b/brownies/legacy/toENDF6/gndsToENDF6.py
@@ -570,7 +570,7 @@ def gammasToENDF6_MF12_13(MT, MF, endfMFList, flags, targetInfo, gammas):
         elif isinstance(angularSubform, angularModule.XYs2d):
             isNotIsotropic = 1
             targetInfo['doProductionGamma'] = True
-            dummy, dummy, MF14 = angularSubform.toENDF6(flags, targetInfo)
+            _, _, MF14 = angularSubform.toENDF6(flags, targetInfo)
             del targetInfo['doProductionGamma']
             del MF14[-1]
             MF14[0] = endfFormatsModule.floatToFunky(gammaEnergy) + endfFormatsModule.floatToFunky(originationLevel) + MF14[0][22:]

--- a/fudge/GNDS_file.py
+++ b/fudge/GNDS_file.py
@@ -14,7 +14,7 @@ If the file is not a *GNDS/XML* file, a raise is executed.
 
 import pathlib
 import xml.sax
-from xml.etree import cElementTree
+from xml.etree import ElementTree as ET
 
 from LUPY.hdf5 import HDF5_present, h5py
 from LUPY import xmlNode as xmlNodeModule  # wrapper around the xml parser:
@@ -148,7 +148,7 @@ def read(fileName, reactionSuite=None, warningNoReactionSuite=True, verbosity=1,
     elif name == groupModule.Groups.moniker:
         return groupModule.read(fileName)
     elif name == fissionFragmentDataModule.FissionFragmentData.moniker:
-        element = cElementTree.parse(fileName).getroot()
+        element = ET.parse(fileName).getroot()
         element = xmlNodeModule.XML_node(element, xmlNodeModule.XML_node.etree)
         fissionFragmentData = fissionFragmentDataModule.FissionFragmentData()
         fissionFragmentData.parseNode(element, [], {})
@@ -233,7 +233,7 @@ def preview(fileName, haltParsingMoniker=stylesModule.Styles.moniker):
         lines.append(lines.pop(-1)[:handler.GNDS_previewColumn] + '</%s>' % handler.haltParsingMoniker)
         if handler.haltParsingMoniker != name: lines.append('</%s>' % name)
 
-        element = cElementTree.fromstring(''.join(lines))
+        element = ET.fromstring(''.join(lines))
         element = xmlNodeModule.XML_node(element, xmlNodeModule.XML_node.etree)
         linkData = {'unresolvedLinks': []}
         if name == reactionSuiteModule.ReactionSuite.moniker:

--- a/fudge/GNDS_file.py
+++ b/fudge/GNDS_file.py
@@ -132,7 +132,7 @@ def read(fileName, reactionSuite=None, warningNoReactionSuite=True, verbosity=1,
     in the file *fileName* into **FUDGE**.  It returns the **FUDGE** instance for the type.
     """
 
-    name, dummy = type(fileName)
+    name, _ = type(fileName)
     if name == reactionSuiteModule.ReactionSuite.moniker:
         kwargs = {'verbosity': verbosity, 'lazyParsing': lazyParsing}
         return reactionSuiteModule.ReactionSuite.readXML_file(fileName, **kwargs)

--- a/fudge/institution.py
+++ b/fudge/institution.py
@@ -13,7 +13,7 @@ Each institution has a unique label and a list of data types. The only restricti
 they be well-formed xml. Codes reading in GNDS files are free to ignore any unrecognized institution or data type.
 """
 
-from xml.etree import ElementTree
+from xml.etree import ElementTree as ET
 from xml.sax import saxutils
 
 from LUPY import ancestry as ancestryModule
@@ -205,7 +205,7 @@ class UnknownInstitutionXML_node:
     def __init__(self, XML_node):
 
         self.__label = XML_node.get( 'label' )
-        self.__stringList = ElementTree.tostring(XML_node.data, encoding='unicode').rstrip().split('\n')
+        self.__stringList = ET.tostring(XML_node.data, encoding='unicode').rstrip().split('\n')
 
     @property
     def label( self ) :
@@ -275,7 +275,7 @@ class UnknownLLNL_XML_child:
 
     def __init__(self, XML_node):
 
-        self.__stringList = saxutils.unescape(ElementTree.tostring(XML_node.data, encoding='unicode')).rstrip().split('\n')
+        self.__stringList = saxutils.unescape(ET.tostring(XML_node.data, encoding='unicode')).rstrip().split('\n')
 
     @property
     def stringList(self):

--- a/fudge/productData/distributions/LLNL_angularEnergy.py
+++ b/fudge/productData/distributions/LLNL_angularEnergy.py
@@ -942,7 +942,7 @@ class LLNLAngularEnergyForm( baseModule.Form ) :
         """     
 
         angular = self.angularSubform.to_xs_pdf_cdf1d( style, tempInfo, indent )
-        dummy, angularEnergy = self.angularEnergySubform.to_xs_pdf_cdf1d( style, tempInfo, indent )
+        _, angularEnergy = self.angularEnergySubform.to_xs_pdf_cdf1d( style, tempInfo, indent )
         return( angularEnergyMCModule.Form( style.label, self.productFrame, angular, angularEnergy ) )
 
     def processMultiGroup( self, style, tempInfo, indent ) :

--- a/fudge/productData/distributions/angular.py
+++ b/fudge/productData/distributions/angular.py
@@ -1548,10 +1548,10 @@ class TwoBody( baseModule.Form ) :
                 else :
                     muLists = [ [ mu_prime_1, mu_prime_4 ] ]
             else :
-                mu_prime_1, dummy = self.productMuInCOM_fromProductMuInLab( mu_prime_min, com_speed, product_com_speed )
+                mu_prime_1, _ = self.productMuInCOM_fromProductMuInLab( mu_prime_min, com_speed, product_com_speed )
                 mu_prime_2 = None
                 if mu_prime_max is not None:
-                    mu_prime_2, dummy = self.productMuInCOM_fromProductMuInLab( mu_prime_max, com_speed, product_com_speed )
+                    mu_prime_2, _ = self.productMuInCOM_fromProductMuInLab( mu_prime_max, com_speed, product_com_speed )
                 muLists = [ [ mu_prime_1, mu_prime_2 ] ]
 
         angular_evaluate = 0.0

--- a/numericalFunctions/ptwXY/Python/Test/Flat/binaryMath/flatMath.py
+++ b/numericalFunctions/ptwXY/Python/Test/Flat/binaryMath/flatMath.py
@@ -123,7 +123,7 @@ def binaryAddSubCheck( count, ls ) :
     ls, resultsC = getXYData( ls, biSectionMax, accuracy )
     results = XYs1 + XYs2
     compareXYs( resultsC, results, "binaryAddSubCheck" )
-    ls, dummy = getXYData( ls, biSectionMax, accuracy )
+    ls, _ = getXYData( ls, biSectionMax, accuracy )
     ls, resultsC = getXYData( ls, biSectionMax, accuracy )
     results = results - XYs2
     compareXYs( resultsC, results, "binaryAddSubCheck" )
@@ -136,7 +136,7 @@ def binaryMulDivCheck( count, ls ) :
     ls, resultsC = getXYData( ls, biSectionMax, accuracy )
     results = XYs1 * XYs2
     compareXYs( resultsC, results, "binaryMulDivCheck" )
-    ls, dummy = getXYData( ls, biSectionMax, accuracy )
+    ls, _ = getXYData( ls, biSectionMax, accuracy )
     ls, resultsC = getXYData( ls, biSectionMax, accuracy )
     results = results / XYs2
     compareXYs( resultsC, results, "binaryMulDivCheck" )

--- a/numericalFunctions/ptwXY/Python/Test/UnitTesting/Others/clip.py
+++ b/numericalFunctions/ptwXY/Python/Test/UnitTesting/Others/clip.py
@@ -80,6 +80,6 @@ count = 0
 while( len( ls ) ) :
     count += 1
     if( count == 6 ) :
-        ls, dummy = getXYData( ls )
-        ls, dummy = getXYData( ls )
+        ls, _ = getXYData( ls )
+        ls, _ = getXYData( ls )
     ls = checkClipping( count, ls )

--- a/numericalFunctions/ptwXY/Python/Test/UnitTesting/Others/mod.py
+++ b/numericalFunctions/ptwXY/Python/Test/UnitTesting/Others/mod.py
@@ -62,7 +62,7 @@ def checkMod( ls ) :
 
     ls, m = getDoubleValue( 'mod', ls )
     ls, data = getXYData( ls )
-    ls, dummy = getXYData( ls )
+    ls, _ = getXYData( ls )
     moded = data % m
     if( len( moded ) != len( data ) ) : raise Exception( '%s: len( moded ) = %d != len( data ) = %d' % ( __file__, len( moded ), len( data ) ) )
     for i, xy in enumerate( moded ) :

--- a/numericalFunctions/ptwXY/Python/Test/UnitTesting/Others/trim.py
+++ b/numericalFunctions/ptwXY/Python/Test/UnitTesting/Others/trim.py
@@ -78,6 +78,6 @@ count = 0
 while( len( ls ) ) :
     count += 1
     if( count == 6 ) :
-        ls, dummy = getXYData( ls )
-        ls, dummy = getXYData( ls )
+        ls, _ = getXYData( ls )
+        ls, _ = getXYData( ls )
     ls = checkClipping( count, ls )

--- a/numericalFunctions/ptwXY/Python/Test/UnitTesting/integrate/integrationXY.py
+++ b/numericalFunctions/ptwXY/Python/Test/UnitTesting/integrate/integrationXY.py
@@ -82,8 +82,8 @@ count = 0
 while( len( ls ) ) :
     count += 1
     if( count == 9 ) :
-        ls, dummy = getXYData( ls )
-        ls, dummy = getXYData( ls )
+        ls, _ = getXYData( ls )
+        ls, _ = getXYData( ls )
     ls, xMin = getDoubleValue( 'xMin', ls )
     ls, xMax = getDoubleValue( 'xMax', ls )
     ls, data = getXYData( ls )

--- a/numericalFunctions/ptwXY/Python/Test/UnitTesting/thinning/thin.py
+++ b/numericalFunctions/ptwXY/Python/Test/UnitTesting/thinning/thin.py
@@ -59,6 +59,6 @@ def thin( label, accuracy, original, data ) :
 while( 1 ) :
     ls, label, accuracy, original = getData( ls, True )
     if( ls is None ) : break
-    ls, label, dummy, data = getData( ls, False )
+    ls, label, _, data = getData( ls, False )
     if( ls is None ) : raise Exception( '%s: missing thinned data for label = "%s"' % ( __file__, label ) )
     thin( label, accuracy, original, data )

--- a/numericalFunctions/ptwXY/Python/Test/UnitTesting/thinning/thinDomain.py
+++ b/numericalFunctions/ptwXY/Python/Test/UnitTesting/thinning/thinDomain.py
@@ -39,7 +39,7 @@ def checkThin( ls ) :
     ls, epsilon = utilitiesModule.getDoubleValue( 'epsilon', ls )
     ls, original = utilitiesModule.getXYData( ls )
     ls, answer = utilitiesModule.getXYData( ls )
-    ls, dummy = utilitiesModule.getXYData( ls )
+    ls, _ = utilitiesModule.getXYData( ls )
     thinned = original.thinDomain( epsilon )
     if( len( answer ) != len( thinned ) ) : raise Exception( '%s: len( answer ) = %d != len( thinned ) = %d for label = "%s"' % \
         ( __file__, len( answer ), len( thinned ), label ) )

--- a/xData/test/test_table.py
+++ b/xData/test/test_table.py
@@ -6,7 +6,7 @@
 # <<END-copyright>>
 
 import unittest
-from xml.etree import cElementTree as parser
+from xml.etree import ElementTree as ET
 
 from xData import table as tableModule
 
@@ -21,7 +21,7 @@ class TestTable(unittest.TestCase):
         for dat in ([-1.7, tableModule.Blank(), 3.2, 0.089], [3.4, 0.5, 4.2, 0.072], [5.6, 1.5, 2.76, 0.064]):
             self.tt.addRow( dat )
         self.xmlstring = '\n'.join( self.tt.toXML_strList() )
-        element = parser.fromstring( self.xmlstring )
+        element = ET.fromstring( self.xmlstring )
         self.tt2 = tableModule.Table.parseNodeUsingClass(element, xPath = [],
                 linkData = {'conversionTable' : {'index':int} })
         self.xmlstring2 = '\n'.join( self.tt2.toXML_strList() )


### PR DESCRIPTION
The first commit applies ElementTree in a consistent way, since cElementTree is [deprecated](https://github.com/python/cpython/commit/a72a98f24a19928e31dcc4cab2cd2ad0f1846e11).

The second commit fixes a potential issue with parenthesis.

The third commit replaces `dummy` with `_` following the Python standard: this should provide better reading and potentially avoiding variable management on function returns.

Feel free to cherry pick as you like.

Are there CI/CD tests to verify if everything is fine?