### PR TITLE
Warn when ACE average heating numbers are written as zeros

### DIFF
--- a/brownies/LANL/toACE/gndsToACE.py
+++ b/brownies/LANL/toACE/gndsToACE.py
@@ -10,9 +10,12 @@ Issues:
     -) When delayed neutrons are present, their multiplicities are added to prompt, and prompt and total nu_bar
         are written. However, their decay constants, etc are currently not written.
     -) Only neutrons distribution data are outputted.
+    -) The average heating numbers (KERMA) in the ESZ block are not calculated and are written as zeros. There is
+        currently no equivalent of NJOY's HEATR module in FUDGE. A warning is emitted when the zeros are written.
 """
 
 import time
+import warnings
 
 from xData import enums as xDataEnumsModule
 from xData import axes as axesModule
@@ -217,6 +220,7 @@ def toACE(self, styleLabel, cdf_style, fileName, evaluationId, productData, dela
     else:
         updateXSSInfo( 'absorption cross section', annotates, XSS, mapCrossSectionToGrid(absorptionXSec) )
     updateXSSInfo( 'elastic cross section', annotates, XSS, elasticXSec )
+    warnings.warn('Average heating numbers (KERMA) are not calculated and are written to the ESZ block as zeros.')
     averageHeating = len( energyGrid ) * [ 0. ]
     updateXSSInfo( 'average heating', annotates, XSS, averageHeating )
 


### PR DESCRIPTION
`gndsToACE.py` fills the ESZ average heating (KERMA) column with zeros unconditionally, and the value is never recomputed elsewhere. Codes that read heating from that column get a valid ACE file in which heating is zero at every energy, so a heating tally silently returns zero instead of failing.

This doesn't calculate the heating numbers (that needs a HEATR equivalent). It just makes the gap visible: a `warnings.warn` where the zeros are written, plus an entry in the module's existing `Issues:` docstring. Generated ACE files are numerically unchanged.

`warnings.warn` rather than the module's `printMessage(verbose > 0, ...)` helper, since gating on `verbose` would leave the default path silent. Happy to switch that, or to raise instead, if you'd prefer.
