### PR TITLE
Remove duplicate "fudge" entry from the packages list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ packages = [
     "fudge.core.math",
     "fudge.core.math.test",
     "fudge.core.utilities",
-    "fudge",
     "fudge.outputChannelData",
     "fudge.outputChannelData.fissionFragmentData",
     "fudge.covariances",


### PR DESCRIPTION
`"fudge"` appears twice in the `[tool.setuptools] packages` list, at lines 24 and 30. This removes the second occurrence.

Purely cosmetic: setuptools dedupes the list, so nothing about the installed result changes. I verified that rather than assuming it, by building a wheel from `master` and from this branch and comparing them:

- 263 installed paths, identical in both once the versioningit version string is normalised.
- 256 of 261 payload files byte identical.
- The 5 that differ are `fudge/fudgeVersion.py` (just the git derived version string) and 4 compiled artifacts, which have identical byte sizes and differ only through build paths embedded by the compiler.

Also confirmed setuptools reports 33 package entries and 32 unique before, 32 and 32 after.
