### PR TITLE
using standard non clashing virtual env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Optional packages matplotlib and PyQT5 are also recommended to support plotting.
 
       Or, using venv:
 
-          python3 -m venv fudge
-          source fudge/bin/activate
+          python3 -m venv .venv
+          source .venv/bin/activate
           pip install wheel
           pip install setuptools
           pip install numpy


### PR DESCRIPTION
the readme suggests making a virtual environment folder with the name fudge, this clashes with the repo folder name fudge. Suggest we switch to ```.venv``` which is the most standard and widely used name for python virtual environments